### PR TITLE
feat(club): ajout du module Club avec gestion des membres

### DIFF
--- a/backend/src/Controller/ClubController.php
+++ b/backend/src/Controller/ClubController.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Controller;
+
+use App\Repository\ClubRepository;
+use App\Repository\UserRepository;
+use App\Entity\Club;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/api/clubs', name: 'api_club_')]
+class ClubController extends AbstractController
+{
+    // Liste tous les clubs
+    #[Route('', name: 'list', methods: ['GET'])]
+    public function list(ClubRepository $clubRepository): JsonResponse
+    {
+        $clubs = $clubRepository->findAll();
+        $data = [];
+        foreach ($clubs as $club) {
+            $data[] = [
+                'id' => $club->getId(),
+                'name' => $club->getName(),
+                'createdAt' => $club->getCreatedAt()?->format('Y-m-d H:i:s'),
+                'clubCaptain' => $club->getClubCaptain()?->getId(),
+            ];
+        }
+        return $this->json($data);
+    }
+
+    // Détail d'un club
+    #[Route('/{id}', name: 'show', methods: ['GET'])]
+    public function show($id, ClubRepository $clubRepository): JsonResponse
+    {
+        $club = $clubRepository->find($id);
+        if (!$club) {
+            return $this->json(['error' => 'Club not found'], 404);
+        }
+        return $this->json([
+            'id' => $club->getId(),
+            'name' => $club->getName(),
+            'createdAt' => $club->getCreatedAt()?->format('Y-m-d H:i:s'),
+            'clubCaptain' => $club->getClubCaptain()?->getId(),
+        ]);
+    }
+
+    // Liste des membres du club
+    #[Route('/{id}/members', name: 'club_members', methods: ['GET'])]
+    public function getClubMembers($id, UserRepository $userRepository): JsonResponse
+    {
+        $members = $userRepository->findBy(['clubId' => $id]);
+        $data = [];
+        foreach ($members as $user) {
+            $data[] = [
+                'id' => $user->getId(),
+                'username' => $user->getUsername(),
+                'email' => $user->getEmail(),
+                'level' => $user->getLevel(),
+                'role' => $user->getRole(),
+            ];
+        }
+        return $this->json($data);
+    }
+
+    // Créer un club
+    #[Route('', name: 'create', methods: ['POST'])]
+    public function create(Request $request, EntityManagerInterface $em, UserRepository $userRepository): JsonResponse
+    {
+        $data = json_decode($request->getContent(), true);
+        if (empty($data['name']) || empty($data['clubCaptainId'])) {
+            return $this->json(['error' => 'Missing required fields'], 400);
+        }
+        $captain = $userRepository->find($data['clubCaptainId']);
+        if (!$captain) {
+            return $this->json(['error' => 'Club captain not found'], 404);
+        }
+        $club = new Club();
+        $club->setName($data['name']);
+        $club->setCreatedAt(new \DateTime());
+        $club->setClubCaptain($captain);
+        $em->persist($club);
+        $em->flush();
+        // Optionnel : on peut faire que le capitaine devienne membre auto (setClubId)
+        $captain->setClubId($club->getId());
+        $em->flush();
+        return $this->json([
+            'id' => $club->getId(),
+            'name' => $club->getName(),
+            'createdAt' => $club->getCreatedAt()?->format('Y-m-d H:i:s'),
+            'clubCaptain' => $club->getClubCaptain()?->getId(),
+        ]);
+    }
+}

--- a/frontend/styx-app/navigation/ClubStackNavigator.js
+++ b/frontend/styx-app/navigation/ClubStackNavigator.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+
+import ClubHomeScreen from '../screens/ClubHomeScreen';      // Le screen “central”
+import CreateClubScreen from '../screens/CreateClubScreen';
+import JoinClubScreen from '../screens/JoinClubScreen';
+import ClubDetailScreen from '../screens/ClubDetailScreen';
+
+const Stack = createNativeStackNavigator();
+
+export default function ClubStackNavigator() {
+  return (
+    <Stack.Navigator screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="ClubHome" component={ClubHomeScreen} />
+      <Stack.Screen name="CreateClub" component={CreateClubScreen} />
+      <Stack.Screen name="JoinClub" component={JoinClubScreen} />
+      <Stack.Screen name="ClubDetail" component={ClubDetailScreen} />
+    </Stack.Navigator>
+  );
+}

--- a/frontend/styx-app/screens/ClubDetailScreen.js
+++ b/frontend/styx-app/screens/ClubDetailScreen.js
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, FlatList, Button, Alert } from 'react-native';
+import { getClub, getClubMembers, leaveClub } from '../services/api';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useNavigation, useRoute } from '@react-navigation/native';
+
+export default function ClubDetailScreen() {
+  const route = useRoute();
+  const { clubId } = route.params;
+  const [club, setClub] = useState(null);
+  const [members, setMembers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const navigation = useNavigation();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setLoading(true);
+      try {
+        const clubData = await getClub(clubId);
+        setClub(clubData);
+        const membersData = await getClubMembers(clubId);
+        setMembers(membersData);
+      } catch (e) {
+        Alert.alert('Erreur', "Impossible de charger le club");
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, [clubId]);
+
+  const handleLeave = async () => {
+    try {
+      const userId = await AsyncStorage.getItem('userId');
+      await leaveClub(userId);
+      Alert.alert('Tu as quitté le club');
+      navigation.navigate('ClubHome');
+    } catch (e) {
+      Alert.alert('Erreur', "Impossible de quitter le club");
+    }
+  };
+
+  if (loading) return <Text>Chargement...</Text>;
+
+  if (!club) return <Text>Club introuvable</Text>;
+
+  return (
+    <View style={{ flex:1, padding:20 }}>
+      <Text style={{ fontSize:22, fontWeight:'bold', marginBottom:8 }}>{club.name}</Text>
+      <Text style={{ color:'#555', marginBottom:12 }}>Capitaine ID: {club.clubCaptain}</Text>
+      <Text style={{ fontSize:18, marginBottom:6 }}>Membres du club :</Text>
+      <FlatList
+        data={members}
+        keyExtractor={item => item.id.toString()}
+        renderItem={({ item }) => (
+          <Text style={{ paddingVertical:4 }}>{item.username} (lvl: {item.level}, rôle: {item.role})</Text>
+        )}
+      />
+      <Button title="Quitter le club" color="#d00" onPress={handleLeave} />
+    </View>
+  );
+}

--- a/frontend/styx-app/screens/ClubHomeScreen.js
+++ b/frontend/styx-app/screens/ClubHomeScreen.js
@@ -1,0 +1,48 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, Button, ActivityIndicator, Alert } from 'react-native';
+import { getUserClub } from '../services/api';
+import { useNavigation } from '@react-navigation/native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export default function ClubHomeScreen() {
+  const navigation = useNavigation();
+  const [club, setClub] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchClub = async () => {
+      setLoading(true);
+      try {
+        const userId = await AsyncStorage.getItem('userId');
+        const clubData = await getUserClub(userId);
+        setClub(clubData);
+      } catch (e) {
+        setClub(null);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchClub();
+  }, []);
+
+  if (loading) return <ActivityIndicator size="large" />;
+
+  if (!club) {
+    return (
+      <View style={{ flex:1, justifyContent:'center', alignItems:'center' }}>
+        <Text style={{ fontSize:18, marginBottom:16 }}>Tu n'es membre d'aucun club.</Text>
+        <Button title="Créer un club" onPress={() => navigation.navigate('CreateClub')} />
+        <Button title="Rejoindre un club" onPress={() => navigation.navigate('JoinClub')} />
+      </View>
+    );
+  }
+
+  return (
+    <View style={{ flex:1, justifyContent:'center', alignItems:'center' }}>
+      <Text style={{ fontSize:22, fontWeight:'bold', marginBottom:16 }}>
+        Ton club : {club.name}
+      </Text>
+      <Button title="Voir le club" onPress={() => navigation.navigate('ClubDetail', { clubId: club.id })} />
+    </View>
+  );
+}

--- a/frontend/styx-app/screens/CreateClubScreen.js
+++ b/frontend/styx-app/screens/CreateClubScreen.js
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, Alert } from 'react-native';
+import { createClub } from '../services/api';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useNavigation } from '@react-navigation/native';
+
+export default function CreateClubScreen() {
+  const [name, setName] = useState('');
+  const navigation = useNavigation();
+
+  const handleCreate = async () => {
+    if (!name) {
+      Alert.alert('Erreur', 'Merci de renseigner le nom du club');
+      return;
+    }
+    try {
+      const userId = await AsyncStorage.getItem('userId');
+      await createClub({ name, clubCaptainId: userId });
+      Alert.alert('Succès', 'Club créé !');
+      navigation.navigate('ClubHome');
+    } catch (e) {
+      Alert.alert('Erreur', "Impossible de créer le club");
+    }
+  };
+
+  return (
+    <View style={{ flex:1, justifyContent:'center', alignItems:'center' }}>
+      <Text style={{ fontSize:22, fontWeight:'bold' }}>Créer un club</Text>
+      <TextInput
+        placeholder="Nom du club"
+        value={name}
+        onChangeText={setName}
+        style={{
+          borderWidth:1, borderColor:'#ccc', borderRadius:6, width:250, marginVertical:16, padding:10
+        }}
+      />
+      <Button title="Créer" onPress={handleCreate} />
+    </View>
+  );
+}

--- a/frontend/styx-app/screens/JoinClubScreen.js
+++ b/frontend/styx-app/screens/JoinClubScreen.js
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, FlatList, Button, Alert, TouchableOpacity } from 'react-native';
+import { getClubs, joinClub } from '../services/api';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useNavigation } from '@react-navigation/native';
+
+export default function JoinClubScreen() {
+  const [clubs, setClubs] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const navigation = useNavigation();
+
+  useEffect(() => {
+    const fetchClubs = async () => {
+      setLoading(true);
+      try {
+        const data = await getClubs();
+        setClubs(data);
+      } catch (e) {
+        setClubs([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchClubs();
+  }, []);
+
+  const handleJoin = async (clubId) => {
+    try {
+      const userId = await AsyncStorage.getItem('userId');
+      await joinClub(userId, clubId);
+      Alert.alert('Succès', 'Tu as rejoint le club !');
+      navigation.navigate('ClubHome');
+    } catch (e) {
+      Alert.alert('Erreur', "Impossible de rejoindre le club");
+    }
+  };
+
+  if (loading) return <Text>Chargement...</Text>;
+
+  return (
+    <View style={{ flex:1, padding:20 }}>
+      <Text style={{ fontSize:20, fontWeight:'bold', marginBottom:12 }}>Liste des clubs</Text>
+      <FlatList
+        data={clubs}
+        keyExtractor={item => item.id.toString()}
+        renderItem={({ item }) => (
+          <View style={{
+            padding:12, marginBottom:10, backgroundColor:'#eee', borderRadius:8, flexDirection:'row', justifyContent:'space-between', alignItems:'center'
+          }}>
+            <Text>{item.name}</Text>
+            <Button title="Rejoindre" onPress={() => handleJoin(item.id)} />
+          </View>
+        )}
+      />
+    </View>
+  );
+}


### PR DESCRIPTION
- Création de l'entité Club et de son repository
- Ajout du ClubController avec endpoints :
  - GET /api/clubs (liste des clubs)
  - GET /api/clubs/{id} (détail)
  - POST /api/clubs (création)
  - GET /api/clubs/{id}/members (membres d'un club)
- Endpoints utilisateur :
  - POST /api/users/{id}/join-club (rejoindre un club)
  - POST /api/users/{id}/leave-club (quitter un club)
  - GET /api/users/{id}/club (afficher le club d'un utilisateur)
- Intégration front React Native :
  - Ecrans ClubHome, CreateClub, JoinClub, ClubDetail
  - API club côté services/api.js

Refactoring navigation pour utiliser un ClubStackNavigator.