### PR TITLE
Feat/club

### DIFF
--- a/backend/config/services.yaml
+++ b/backend/config/services.yaml
@@ -4,6 +4,7 @@
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
+    club_logos_dir: '%kernel.project_dir%/public/uploads/club-logos'
 
 services:
     # default configuration for services in *this* file

--- a/backend/src/Controller/ClubController.php
+++ b/backend/src/Controller/ClubController.php
@@ -136,6 +136,12 @@ class ClubController extends AbstractController
             }
         }
 
+        foreach ($usersDuClub as $membre) {
+            if ($membre->getId() !== $user->getId() && $membre->getPoste() === $poste) {
+                return $this->json(['error' => 'Poste déjà pris'], 409);
+            }
+        }
+
         $user->setPoste($poste);
         $em->flush();
 

--- a/backend/src/Entity/Club.php
+++ b/backend/src/Entity/Club.php
@@ -32,6 +32,9 @@ class Club
     #[ORM\OneToMany(mappedBy: "club", targetEntity: User::class)]
     private Collection $members;
 
+    #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    private ?string $image = null;
+
     public function __construct()
     {
         $this->members = new ArrayCollection();
@@ -99,6 +102,17 @@ class Club
                 $member->setClub(null);
             }
         }
+        return $this;
+    }
+
+    public function getImage(): ?string
+    {
+        return $this->image;
+    }
+
+    public function setImage(?string $image): self
+    {
+        $this->image = $image;
         return $this;
     }
 }

--- a/frontend/styx-app/navigation/ClubStackNavigator.js
+++ b/frontend/styx-app/navigation/ClubStackNavigator.js
@@ -5,7 +5,8 @@ import ClubHomeScreen from '../screens/ClubHomeScreen';      // Le screen “cen
 import CreateClubScreen from '../screens/CreateClubScreen';
 import JoinClubScreen from '../screens/JoinClubScreen';
 import ClubDetailScreen from '../screens/ClubDetailScreen';
-import NoClubScreen from '../screens/NoClubScreen';        // Le screen “d’accueil” si pas de club
+import NoClubScreen from '../screens/NoClubScreen';
+import ClubManageScreen from '../screens/ClubManageScreen';
 
 const Stack = createNativeStackNavigator();
 
@@ -17,6 +18,7 @@ export default function ClubStackNavigator() {
       <Stack.Screen name="CreateClub" component={CreateClubScreen} />
       <Stack.Screen name="JoinClub" component={JoinClubScreen} />
       <Stack.Screen name="ClubDetail" component={ClubDetailScreen} />
+      <Stack.Screen name="ClubManageScreen" component={ClubManageScreen} />
     </Stack.Navigator>
   );
 }

--- a/frontend/styx-app/navigation/MainNavigator.js
+++ b/frontend/styx-app/navigation/MainNavigator.js
@@ -5,7 +5,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import BottomTabNavigator from './BottomTabNavigator';
 import CreateGameScreen from '../screens/CreateGameScreen';
 import UserDetailsScreen from '../screens/UserDetailsScreen';
-import GameSearchScreen from '../screens/GameSearchScreen'; // ✅ Ajout de l'import
+import GameSearchScreen from '../screens/GameSearchScreen';
 
 const Stack = createNativeStackNavigator();
 

--- a/frontend/styx-app/package-lock.json
+++ b/frontend/styx-app/package-lock.json
@@ -15,6 +15,7 @@
         "@react-navigation/native-stack": "^7.3.11",
         "axios": "^1.9.0",
         "expo": "^53.0.7",
+        "expo-image-picker": "~16.1.4",
         "expo-status-bar": "~2.2.3",
         "react": "19.0.0",
         "react-native": "0.79.2",
@@ -4123,6 +4124,25 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-5.1.0.tgz",
+      "integrity": "sha512-sEBx3zDQIODWbB5JwzE7ZL5FJD+DK3LVLWBVJy6VzsqIA6nDEnSFnsnWyCfCTSvbGigMATs1lgkC2nz3Jpve1Q==",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-16.1.4.tgz",
+      "integrity": "sha512-bTmmxtw1AohUT+HxEBn2vYwdeOrj1CLpMXKjvi9FKSoSbpcarT4xxI0z7YyGwDGHbrJqyyic3I9TTdP2J2b4YA==",
+      "dependencies": {
+        "expo-image-loader": "~5.1.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {

--- a/frontend/styx-app/package.json
+++ b/frontend/styx-app/package.json
@@ -26,7 +26,8 @@
     "react-native-progress": "^5.0.1",
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "^5.4.0",
-    "react-native-screens": "^4.10.0"
+    "react-native-screens": "^4.10.0",
+    "expo-image-picker": "~16.1.4"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/frontend/styx-app/screens/ClubDetailScreen.js
+++ b/frontend/styx-app/screens/ClubDetailScreen.js
@@ -79,23 +79,6 @@ export default function ClubDetailScreen({ route }) {
     }
   };
 
-  const handleToggleRemplacant = async () => {
-    if (!userInfo?.id) return;
-    const isRemplacant = members.find(m => m.id === userInfo.id && m.poste === 'REMPLACANT');
-    try {
-      await setUserPoste(clubId, userInfo.id, isRemplacant ? null : 'REMPLACANT');
-      setMembers(prev =>
-        prev.map(m =>
-          m.id === userInfo.id
-            ? { ...m, poste: isRemplacant ? null : 'REMPLACANT' }
-            : m
-        )
-      );
-    } catch (e) {
-      Alert.alert('Erreur', "Impossible de gérer le statut remplaçant");
-    }
-  };
-
   const inviteLocal = `exp://172.29.193.238:8081?clubId=${club?.id}`;
   const inviteTunnel = `exp://6vrrl3c-anonymous-8081.exp.direct?clubId=${club?.id}`;
 

--- a/frontend/styx-app/screens/ClubDetailScreen.js
+++ b/frontend/styx-app/screens/ClubDetailScreen.js
@@ -3,6 +3,8 @@ import { View, Text, StyleSheet, Image, TouchableOpacity, ActivityIndicator, Scr
 import { getClub, getClubMembers, setUserPoste, leaveClub, transferCaptain } from '../services/api';
 import { AuthContext } from '../contexts/AuthContext';
 import { useNavigation } from '@react-navigation/native';
+import { Ionicons } from '@expo/vector-icons';
+
 
 const defaultClubImage = require('../assets/club-default.png');
 const defaultPlayerImage = require('../assets/player-default.png');
@@ -89,7 +91,7 @@ export default function ClubDetailScreen({ route }) {
   • Si tu es sur le même wifi que moi, ouvre ce lien :
   ${inviteLocal}
 
-  • Sinon, utilise ce lien universel (tunnel) :
+  • Sinon, utilise ce lien universel (tunnel) : 
   ${inviteTunnel}
 
   Ouvre-le avec Expo Go sur ton téléphone !
@@ -314,9 +316,17 @@ export default function ClubDetailScreen({ route }) {
             </View>
 
             {/* LISTE JOUEURS */}
-            <View style={styles.sectionTitleContainer}>
+            <View style={styles.sectionTitleRow}>
               <View style={styles.sectionTitleBar} />
               <Text style={styles.sectionTitle}>Joueurs</Text>
+              <TouchableOpacity
+                style={styles.inviteBtn}
+                onPress={handleShareInvite}
+                activeOpacity={0.7}
+              >
+                <Ionicons name="person-add" size={18} color="#00D9FF" style={{ marginRight: 5 }} />
+                <Text style={styles.inviteBtnText}>Inviter</Text>
+              </TouchableOpacity>
             </View>
             <View>
               {sortedMembers.map(item => (
@@ -341,29 +351,21 @@ export default function ClubDetailScreen({ route }) {
                 </View>
               ))}
             </View>
-            <TouchableOpacity style={styles.addBtn} onPress={handleShareInvite}>
-              <Text style={styles.addBtnText}>Inviter des joueurs à votre club</Text>
+            <View style={styles.actionBar}>
+              {userInfo.id === captainId && (
+                <TouchableOpacity
+                  style={styles.actionBtn}
+                  onPress={() => navigation.navigate('ClubManageScreen', { club, members })}
+                >
+                  <Text style={styles.actionBtnText}>Gérer</Text>
+                </TouchableOpacity>
+              )}
+            </View>
+
+            <TouchableOpacity style={styles.leaveBtn} onPress={handleLeave}>
+              <Text style={styles.leaveBtnText}>Quitter le club</Text>
             </TouchableOpacity>
 
-
-            {/* -- BOUTON QUITTER LE CLUB -- */}
-            <TouchableOpacity
-              style={{
-                marginTop: 36,
-                marginBottom: 36,
-                backgroundColor: '#d00',
-                borderRadius: 24,
-                paddingVertical: 18,
-                alignItems: 'center',
-                width: '94%',
-                alignSelf: 'center',
-              }}
-              onPress={handleLeave}
-            >
-              <Text style={{ color: '#fff', fontWeight: 'bold', fontSize: 18 }}>
-                Quitter le club
-              </Text>
-            </TouchableOpacity>
           </View>
         )}
 
@@ -618,21 +620,6 @@ const styles = StyleSheet.create({
   },
 
   // Ajout joueurs
-  addBtn: {
-    marginTop: 18,
-    marginBottom: 10,
-    backgroundColor: '#00D9FF',
-    borderRadius: 24,
-    paddingVertical: 15,
-    alignItems: 'center',
-    width: '98%',
-    alignSelf: 'center',
-  },
-  addBtnText: {
-    color: '#050A23',
-    fontWeight: 'bold',
-    fontSize: 17,
-  },
   captainDotField: {
     position: 'absolute',
     top: 2,
@@ -657,12 +644,31 @@ const styles = StyleSheet.create({
     borderColor: '#fff',
     zIndex: 10,
   },
-  sectionTitleContainer: {
+
+  sectionTitleRow: {
+  flexDirection: 'row',
+  alignItems: 'center',
+  marginVertical: 14,
+  marginBottom: 6,
+  },
+  inviteBtn: {
     flexDirection: 'row',
     alignItems: 'center',
-    marginVertical: 14,
-    marginBottom: 6,
+    marginLeft: 'auto',
+    backgroundColor: 'rgba(0,217,255,0.13)',
+    paddingHorizontal: 13,
+    paddingVertical: 5,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: '#00D9FF',
   },
+  inviteBtnText: {
+    color: '#00D9FF',
+    fontWeight: 'bold',
+    fontSize: 14.7,
+    letterSpacing: 0.4,
+  },
+
   sectionTitleBar: {
     width: 7,
     height: 28,
@@ -678,6 +684,50 @@ const styles = StyleSheet.create({
     textShadowColor: '#232346',
     textShadowOffset: { width: 1, height: 1 },
     textShadowRadius: 3,
+  },
+
+  actionBar: {
+  flexDirection: 'row',
+  justifyContent: 'center',
+  alignItems: 'center',
+  gap: 16,
+  marginTop: 18,
+  marginBottom: 6,
+  },
+  actionBtn: {
+    backgroundColor: '#00D9FF',
+    borderRadius: 18,
+    paddingVertical: 13,
+    paddingHorizontal: 30,
+    alignItems: 'center',
+    marginHorizontal: 4,
+    minWidth: 100,
+  },
+  actionBtnText: {
+    color: '#050A23',
+    fontWeight: 'bold',
+    fontSize: 16.5,
+    letterSpacing: 0.5,
+  },
+  leaveBtn: {
+    marginTop: 6,
+    marginBottom: 24,
+    backgroundColor: '#E33232',
+    borderRadius: 18,
+    paddingVertical: 13,
+    paddingHorizontal: 38,
+    alignItems: 'center',
+    alignSelf: 'center',
+    shadowColor: '#E33232',
+    shadowOpacity: 0.25,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 6,
+  },
+  leaveBtnText: {
+    color: '#fff',
+    fontWeight: 'bold',
+    fontSize: 16.5,
+    letterSpacing: 0.7,
   },
 
 });

--- a/frontend/styx-app/screens/ClubDetailScreen.js
+++ b/frontend/styx-app/screens/ClubDetailScreen.js
@@ -77,9 +77,23 @@ export default function ClubDetailScreen({ route }) {
         )
       );
     } catch (e) {
-      Alert.alert('Erreur', e?.response?.data?.error || 'Impossible de prendre ce poste');
+      if (e?.response?.data?.error === 'Poste déjà pris') {
+        // Attribuer remplaçant automatiquement !
+        await setUserPoste(clubId, userInfo.id, 'REMPLACANT');
+        setMembers(prev =>
+          prev.map(m =>
+            m.id === userInfo.id
+              ? { ...m, poste: 'REMPLACANT' }
+              : m
+          )
+        );
+        Alert.alert("Poste occupé", "Ce poste est déjà pris. Tu as été placé en remplaçant.");
+      } else {
+        Alert.alert('Erreur', e?.response?.data?.error || 'Impossible de prendre ce poste');
+      }
     }
   };
+
 
   const inviteLocal = `exp://172.29.193.238:8081?clubId=${club?.id}`;
   const inviteTunnel = `exp://6vrrl3c-anonymous-8081.exp.direct?clubId=${club?.id}`;

--- a/frontend/styx-app/screens/ClubDetailScreen.js
+++ b/frontend/styx-app/screens/ClubDetailScreen.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useContext } from 'react';
-import { View, Text, StyleSheet, Image, TouchableOpacity, ActivityIndicator, ScrollView, Dimensions, Alert } from 'react-native';
+import { View, Text, StyleSheet, Image, TouchableOpacity, ActivityIndicator, ScrollView, Dimensions, Alert, Share } from 'react-native';
 import { getClub, getClubMembers, setUserPoste, leaveClub, transferCaptain } from '../services/api';
 import { AuthContext } from '../contexts/AuthContext';
 import { useNavigation } from '@react-navigation/native';
@@ -95,6 +95,28 @@ export default function ClubDetailScreen({ route }) {
       Alert.alert('Erreur', "Impossible de gérer le statut remplaçant");
     }
   };
+
+  const inviteLocal = `exp://172.29.193.238:8081?clubId=${club?.id}`;
+  const inviteTunnel = `exp://6vrrl3c-anonymous-8081.exp.direct?clubId=${club?.id}`;
+
+  const handleShareInvite = async () => {
+    try {
+      await Share.share({
+        message: `🚀 Rejoins mon club sur Styx !\n
+  • Si tu es sur le même wifi que moi, ouvre ce lien :
+  ${inviteLocal}
+
+  • Sinon, utilise ce lien universel (tunnel) :
+  ${inviteTunnel}
+
+  Ouvre-le avec Expo Go sur ton téléphone !
+  (ou scanne le QR code de l’app, ou copie le lien)`,
+      });
+    } catch (error) {
+      Alert.alert('Erreur', "Impossible d’ouvrir la fenêtre de partage");
+    }
+  };
+
 
   const handleLeave = async () => {
     Alert.alert(
@@ -336,9 +358,10 @@ export default function ClubDetailScreen({ route }) {
                 </View>
               ))}
             </View>
-            <TouchableOpacity style={styles.addBtn}>
-              <Text style={styles.addBtnText}>Ajouter des joueurs à votre club</Text>
+            <TouchableOpacity style={styles.addBtn} onPress={handleShareInvite}>
+              <Text style={styles.addBtnText}>Inviter des joueurs à votre club</Text>
             </TouchableOpacity>
+
 
             {/* -- BOUTON QUITTER LE CLUB -- */}
             <TouchableOpacity

--- a/frontend/styx-app/screens/ClubDetailScreen.js
+++ b/frontend/styx-app/screens/ClubDetailScreen.js
@@ -97,19 +97,34 @@ export default function ClubDetailScreen({ route }) {
   };
 
   const handleLeave = async () => {
-    try {
-      const userId = userInfo?.id;
-      await leaveClub(userId); // <= juste ça !
-      Alert.alert('Tu as quitté le club');
-      navigation.reset({
-        index: 0,
-        routes: [{ name: 'NoClubScreen' }]
-      });
-    } catch (e) {
-      Alert.alert('Erreur', "Impossible de quitter le club");
-      console.log('Erreur leaveClub :', e?.response?.data, e.message, e);
-    }
+    Alert.alert(
+      'Confirmation',
+      'Es-tu sûr de vouloir quitter le club ?',
+      [
+        { text: 'Annuler', style: 'cancel' },
+        { 
+          text: 'Oui, quitter', 
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              const userId = userInfo?.id;
+              await leaveClub(userId);
+              Alert.alert('Tu as quitté le club');
+              navigation.reset({
+                index: 0,
+                routes: [{ name: 'NoClubScreen' }]
+              });
+            } catch (e) {
+              Alert.alert('Erreur', "Impossible de quitter le club");
+              console.log('Erreur leaveClub :', e?.response?.data, e.message, e);
+            }
+          }
+        },
+      ],
+      { cancelable: true }
+    );
   };
+
 
 
 
@@ -366,11 +381,11 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    paddingTop: 26,
+    paddingTop: 40,
     paddingHorizontal: 12,
     paddingBottom: 10,
   },
-  clubImage: {
+  clubImage: {  
     width: 70,
     height: 70,
     borderRadius: 35,

--- a/frontend/styx-app/screens/ClubManageScreen.js
+++ b/frontend/styx-app/screens/ClubManageScreen.js
@@ -1,0 +1,345 @@
+import React, { useEffect, useState } from 'react';
+import {
+  View, Text, StyleSheet, TextInput, TouchableOpacity,
+  Image, Alert, ScrollView, ActivityIndicator
+} from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+import { getClub, getClubMembers, updateClub, uploadClubLogo, kickMember, blockMember, setUserPoste, transferCaptain } from '../services/api';
+import { useNavigation, useRoute } from '@react-navigation/native';
+import { Ionicons } from '@expo/vector-icons';
+
+const defaultPlayerImage = require('../assets/player-default.png');
+
+export default function ClubManageScreen() {
+  const navigation = useNavigation();
+  const route = useRoute();
+  const { club: initialClub, members: initialMembers } = route.params || {};
+  const [club, setClub] = useState(initialClub || null);
+  const [members, setMembers] = useState(initialMembers || []);
+  const [name, setName] = useState(initialClub?.name || '');
+  const [loading, setLoading] = useState(false);
+  const [uploading, setUploading] = useState(false);
+
+  // Re-fetch les infos du club si besoin
+  useEffect(() => {
+    if (!club?.id) return;
+    (async () => {
+      setLoading(true);
+      try {
+        const [freshClub, freshMembers] = await Promise.all([
+          getClub(club.id),
+          getClubMembers(club.id)
+        ]);
+        setClub(freshClub);
+        setMembers(freshMembers);
+        setName(freshClub.name);
+      } catch (e) {}
+      setLoading(false);
+    })();
+  }, [club?.id]);
+
+  const handlePickLogo = async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      quality: 0.7,
+      allowsEditing: true,
+      aspect: [1, 1]
+    });
+    if (!result.cancelled) {
+      setUploading(true);
+      try {
+        const uri = result.assets ? result.assets[0].uri : result.uri; // selon version expo
+        const filename = uri.split('/').pop();
+        const type = 'image/' + filename.split('.').pop();
+        const formData = new FormData();
+        formData.append('logo', { uri, name: filename, type });
+        const updated = await uploadClubLogo(club.id, formData);
+        setClub(c => ({ ...c, image: updated.image }));
+        Alert.alert('Succès', "Logo mis à jour !");
+      } catch (e) {
+        Alert.alert('Erreur', "Erreur lors de l’upload du logo");
+      }
+      setUploading(false);
+    }
+  };
+
+  const handleSaveName = async () => {
+    if (!name || name.trim().length < 2) {
+      Alert.alert('Erreur', 'Le nom du club est trop court.');
+      return;
+    }
+    setLoading(true);
+    try {
+      const updated = await updateClub(club.id, { name });
+      setClub(c => ({ ...c, name: updated.name }));
+      Alert.alert('Succès', 'Nom du club mis à jour !');
+    } catch (e) {
+      Alert.alert('Erreur', "Impossible de modifier le nom");
+    }
+    setLoading(false);
+  };
+
+  const handleKick = memberId => {
+    Alert.alert(
+      "Exclure ce joueur",
+      "Tu es sûr de vouloir virer ce joueur du club ?",
+      [
+        { text: 'Annuler', style: 'cancel' },
+        {
+          text: 'Virer',
+          style: 'destructive',
+          onPress: async () => {
+            setLoading(true);
+            try {
+              await kickMember(club.id, memberId);
+              setMembers(members.filter(m => m.id !== memberId));
+            } catch (e) {
+              Alert.alert('Erreur', "Impossible de virer ce joueur");
+            }
+            setLoading(false);
+          }
+        }
+      ]
+    );
+  };
+
+  const handleBlock = memberId => {
+    Alert.alert(
+      "Bloquer ce joueur",
+      "Le joueur sera bloqué et ne pourra plus revenir. Continuer ?",
+      [
+        { text: 'Annuler', style: 'cancel' },
+        {
+          text: 'Bloquer',
+          style: 'destructive',
+          onPress: async () => {
+            setLoading(true);
+            try {
+              await blockMember(club.id, memberId);
+              setMembers(members.filter(m => m.id !== memberId));
+            } catch (e) {
+              Alert.alert('Erreur', "Impossible de bloquer ce joueur");
+            }
+            setLoading(false);
+          }
+        }
+      ]
+    );
+  };
+
+  const handleChangePoste = (userId, currentPoste) => {
+    Alert.prompt(
+      "Changer de poste",
+      "Entre le nouveau poste pour ce joueur (ex : 'BU', 'MC', ...). Vide pour retirer.",
+      [
+        { text: "Annuler", style: "cancel" },
+        {
+          text: "OK",
+          onPress: async (poste) => {
+            setLoading(true);
+            try {
+              await setUserPoste(club.id, userId, poste || null);
+              setMembers(members.map(m => m.id === userId ? { ...m, poste } : m));
+            } catch (e) {
+              Alert.alert('Erreur', "Impossible de modifier le poste");
+            }
+            setLoading(false);
+          }
+        }
+      ],
+      'plain-text',
+      currentPoste || ''
+    );
+  };
+
+  const handleTransferCaptain = (member) => {
+    Alert.alert(
+      "Donner le capitanat",
+      `Tu es sûr de vouloir transférer le capitanat à ${member.username || member.nom} ?`,
+      [
+        { text: "Annuler", style: "cancel" },
+        {
+          text: "Oui, transférer",
+          onPress: async () => {
+            setLoading(true);
+            try {
+              await transferCaptain(club.id, member.id);
+              Alert.alert("Succès", "Le capitanat a été transféré.");
+              navigation.goBack();
+            } catch (e) {
+              Alert.alert("Erreur", "Impossible de transférer le capitanat.");
+            }
+            setLoading(false);
+          }
+        }
+      ]
+    );
+  };
+
+  if (loading) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: '#111' }}>
+        <ActivityIndicator size="large" color="#00D9FF" />
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView style={{ flex: 1, backgroundColor: '#111' }}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={handlePickLogo}>
+          <Image
+            source={club.image ? { uri: club.image } : require('../assets/club-default.png')}
+            style={styles.clubImage}
+          />
+          {uploading && <ActivityIndicator color="#00D9FF" style={styles.uploadLoader} />}
+          <Ionicons name="camera" size={22} color="#00D9FF" style={styles.editIcon} />
+        </TouchableOpacity>
+        <View style={{ flex: 1, marginLeft: 16 }}>
+          <TextInput
+            value={name}
+            onChangeText={setName}
+            style={styles.nameInput}
+            placeholder="Nom du club"
+            placeholderTextColor="#555"
+            editable={!loading}
+          />
+          <TouchableOpacity style={styles.saveBtn} onPress={handleSaveName} disabled={loading}>
+            <Text style={styles.saveBtnText}>Modifier le nom</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+
+      <Text style={styles.sectionTitle}>Gestion des membres</Text>
+      {members.map((m) => (
+        <View key={m.id} style={styles.memberRow}>
+          <Image
+            source={m.image ? { uri: m.image } : defaultPlayerImage}
+            style={styles.memberAvatar}
+          />
+          <View style={{ flex: 1 }}>
+            <Text style={{ color: '#fff', fontWeight: '700' }}>{m.username || m.nom}</Text>
+            <Text style={{ color: '#82E482', fontSize: 13 }}>Poste : {m.poste || '-'}</Text>
+          </View>
+          <TouchableOpacity
+            style={styles.iconBtn}
+            onPress={() => handleChangePoste(m.id, m.poste)}
+          >
+            <Ionicons name="pencil" size={18} color="#00D9FF" />
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={styles.iconBtn}
+            onPress={() => handleKick(m.id)}
+          >
+            <Ionicons name="person-remove" size={19} color="#e23030" />
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={styles.iconBtn}
+            onPress={() => handleBlock(m.id)}
+          >
+            <Ionicons name="close-circle" size={20} color="#b70000" />
+          </TouchableOpacity>
+          {club.clubCaptain?.id !== m.id && (
+            <TouchableOpacity
+              style={styles.iconBtn}
+              onPress={() => handleTransferCaptain(m)}
+            >
+              <Ionicons name="star" size={19} color="#FFD700" />
+            </TouchableOpacity>
+          )}
+        </View>
+      ))}
+      <View style={{ height: 60 }} />
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#171a24',
+    padding: 20,
+    paddingBottom: 10,
+    borderRadius: 12,
+    margin: 14,
+    marginBottom: 8
+  },
+  clubImage: {
+    width: 82,
+    height: 82,
+    borderRadius: 50,
+    borderWidth: 3,
+    borderColor: '#00D9FF',
+    backgroundColor: '#222',
+  },
+  editIcon: {
+    position: 'absolute',
+    right: 5,
+    bottom: 7,
+    backgroundColor: '#111',
+    padding: 4,
+    borderRadius: 20
+  },
+  uploadLoader: {
+    position: 'absolute',
+    alignSelf: 'center',
+    top: 28,
+    left: 28,
+    zIndex: 10
+  },
+  nameInput: {
+    color: '#fff',
+    fontSize: 23,
+    fontWeight: 'bold',
+    letterSpacing: 0.5,
+    borderBottomWidth: 1,
+    borderColor: '#222',
+    marginBottom: 8,
+    backgroundColor: '#23284a',
+    borderRadius: 6,
+    padding: 8,
+  },
+  saveBtn: {
+    backgroundColor: '#00D9FF',
+    paddingVertical: 7,
+    borderRadius: 9,
+    alignSelf: 'flex-start',
+    paddingHorizontal: 20,
+    marginTop: 3,
+  },
+  saveBtnText: {
+    color: '#181818',
+    fontWeight: '700'
+  },
+  sectionTitle: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#00D9FF',
+    marginVertical: 18,
+    marginLeft: 18,
+  },
+  memberRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#23284a',
+    marginHorizontal: 13,
+    marginBottom: 12,
+    borderRadius: 12,
+    padding: 13,
+  },
+  memberAvatar: {
+    width: 43,
+    height: 43,
+    borderRadius: 22,
+    marginRight: 13,
+    backgroundColor: '#222'
+  },
+  iconBtn: {
+    marginHorizontal: 2,
+    padding: 6,
+    borderRadius: 16,
+    backgroundColor: '#161D2C',
+    marginLeft: 4,
+  }
+});

--- a/frontend/styx-app/services/api.js
+++ b/frontend/styx-app/services/api.js
@@ -104,4 +104,18 @@ export const transferCaptain = async (clubId, newCaptainId) => {
   return api.post(`/clubs/${clubId}/transfer-captain`, { newCaptainId });
 };
 
+export const updateClub = (clubId, data) =>
+  api.patch(`/clubs/${clubId}`, data);
+
+export const uploadClubLogo = (clubId, formData) =>
+  api.post(`/clubs/${clubId}/upload-logo`, formData, {
+    headers: { 'Content-Type': 'multipart/form-data' }
+  });
+
+export const kickMember = (clubId, memberId) =>
+  api.post(`/clubs/${clubId}/kick`, { memberId });
+
+export const blockMember = (clubId, memberId) =>
+  api.post(`/clubs/${clubId}/block`, { memberId });
+
 export default api;


### PR DESCRIPTION
# 🚀 Ajout d'une gestion avancée de clubs (Front + Back) — Inviter, gérer, modifier logo/nom, capitanat, etc.

## Résumé

Cette PR apporte de nombreuses améliorations à la gestion des clubs sur l’app *Styx*, côté front **ET** back :

- Nouvelle UI/UX de la page Club
- Bouton **inviter** des joueurs (partage de lien Expo local/tunnel)
- Accès à une page “Gérer le club” (pour le capitaine)
- Fonctionnalités de gestion du club :  
  - Changer le nom
  - Modifier le logo
  - Virer/bloquer un joueur
  - Modifier le poste d’un joueur
  - Transférer le capitanat (avec confirmation)
- Confirmation avant de quitter un club
- Mise à jour des routes/API nécessaires côté back (Symfony)
- Nettoyage et simplification CSS front (React Native)

---

## Détail des changements

### 🎨 **Front (React Native)**

- Nouvelle structure pour la page `ClubDetailScreen`
  - Bouton **Inviter** à droite du titre “Joueurs”, stylé avec un `+` (Ionicons)
  - Action de partage (lien local et tunnel Expo) avec `Share`
  - Bouton **Gérer le club** réservé au capitaine, en-dessous de la liste
  - Bouton **Quitter le club** en bas avec confirmation (Alert)
- Refactor CSS (suppression de styles inutiles, homogénéité)
- Navigation : ajout du screen “ClubManageScreen” dans le stack Club
- Ajout de la gestion d’invitation (Share API)
- Affichage dynamique du bouton Gérer/Inviter en fonction du rôle
- Utilisation des assets locaux pour les images par défaut (`assets/`)



### 🛠️ Back (Symfony)
- Ajout de routes/méthodes :

  - /api/clubs/{clubId}/set-poste/{userId} (POST)

  - /api/clubs/{clubId}/transfer-captain (POST)

  - /api/users/{id}/leave-club (POST)

- Sécurité renforcée (vérif club/capitanat, gestion d’erreurs)
- Mise à jour des entités (User, Club) pour exposer le poste, le rôle, etc.

- À préparer :

  - Endpoint pour upload du logo de club : POST /api/clubs/{id}/upload-logo

  - Stockage : dossier public/uploads/club-logos

  - Retourne l’URL d’accès pour le front
