### PR TITLE
feat/more on bench & adding no role

### DIFF
--- a/backend/src/Controller/ClubController.php
+++ b/backend/src/Controller/ClubController.php
@@ -118,11 +118,11 @@ class ClubController extends AbstractController
         int $userId
     ): JsonResponse {
         $data = json_decode($request->getContent(), true);
-        $poste = $data['poste'] ?? null;
 
-        if ($poste === null) {
+        if (!array_key_exists('poste', $data)) {
             return $this->json(['error' => 'Aucun poste précisé'], 400);
         }
+        $poste = $data['poste'];
 
         $club = $clubRepository->find($clubId);
         $user = $userRepository->find($userId);
@@ -136,7 +136,7 @@ class ClubController extends AbstractController
         }
 
         // Un seul joueur par poste... sauf pour les remplaçants !
-        if ($poste !== 'REMPLACANT') {
+        if ($poste !== null && $poste !== 'REMPLACANT') {
             $usersDuClub = $userRepository->findBy(['club' => $club]);
             foreach ($usersDuClub as $membre) {
                 if ($membre->getId() !== $user->getId() && $membre->getPoste() === $poste) {

--- a/frontend/styx-app/screens/ClubDetailScreen.js
+++ b/frontend/styx-app/screens/ClubDetailScreen.js
@@ -342,7 +342,9 @@ export default function ClubDetailScreen({ route }) {
                 </View>
                 <View style={{ flex: 1 }}>
                   <Text style={styles.playerName}>{item.username || item.nom}</Text>
-                  <Text style={styles.playerPosteList}>Poste : {item.poste || '-'}</Text>
+                  <Text style={styles.playerPosteList}>
+                    Poste : {item.poste ? item.poste : 'Aucun'}
+                  </Text>
                 </View>
                 <TouchableOpacity style={styles.profileBtn}>
                   <Text style={styles.profileBtnText}>Profil</Text>

--- a/frontend/styx-app/screens/ClubManageScreen.js
+++ b/frontend/styx-app/screens/ClubManageScreen.js
@@ -12,10 +12,10 @@ import { AuthContext } from '../contexts/AuthContext';
 const defaultPlayerImage = require('../assets/player-default.png');
 
 const POSTES_11 = [
-  { key: 'GB', label: 'Gardien' },
+  { key: 'GB', label: 'GB' },
   { key: 'DG', label: 'DG' },
-  { key: 'DC1', label: 'DC' },
-  { key: 'DC2', label: 'DC' },
+  { key: 'DC1', label: 'DC1' },
+  { key: 'DC2', label: 'DC2' },
   { key: 'DD', label: 'DD' },
   { key: 'MG', label: 'MG' },
   { key: 'MC', label: 'MC' },
@@ -23,7 +23,7 @@ const POSTES_11 = [
   { key: 'AG', label: 'AG' },
   { key: 'BU', label: 'BU' },
   { key: 'AD', label: 'AD' },
-  { key: 'REMPLACANT', label: 'Remplaçant' },
+  { key: 'REMPLACANT', label: 'REMPLACANT' },
 ];
 
 export default function ClubManageScreen() {
@@ -249,7 +249,9 @@ export default function ClubManageScreen() {
             />
             <View style={{ flex: 1 }}>
               <Text style={{ color: '#fff', fontWeight: '700' }}>{m.username || m.nom}</Text>
-              <Text style={{ color: '#82E482', fontSize: 13 }}>Poste : {m.poste || '-'}</Text>
+              <Text style={{ color: '#82E482', fontSize: 13 }}>
+                Poste : {m.poste === null ? 'Aucun' : m.poste}
+              </Text>
               <TouchableOpacity
                 style={styles.editPosteBtn}
                 onPress={() => setPosteModal({ open: true, member: m })}


### PR DESCRIPTION
# 📦 Pull Request — Affichage “Aucun poste” pour les joueurs sans poste

## Objectif

Améliorer la lisibilité de la gestion des membres en affichant **“Aucun”** lorsque le poste d’un joueur est vide (`null`).

---

## ✨ Changements apportés

### 1. ClubManageScreen.js

**Avant :**
```jsx
<Text style={{ color: '#82E482', fontSize: 13 }}>
  Poste : {m.poste || '-'}
</Text>
**Après :**

jsx
Copier
Modifier
<Text style={{ color: '#82E482', fontSize: 13 }}>
  Poste : {m.poste === null ? 'Aucun' : m.poste}
</Text>

```

---

## 🧪 À tester
Ajouter/retirer le poste d’un joueur : il doit apparaître “Aucun” à la place du poste dans toutes les listes.

Vérifier que l’affichage des autres postes et des remplaçants n’est pas modifié.

