### PR TITLE
✨ UX: Validation des noms de clubs (mot interdit, doublons…) + affichage zoomé des logos à la création

### DIFF
--- a/backend/src/Controller/ClubController.php
+++ b/backend/src/Controller/ClubController.php
@@ -82,6 +82,25 @@ class ClubController extends AbstractController
         if (mb_strlen($name) > 32) {
             return $this->json(['error' => 'Le nom du club ne doit pas dépasser 32 caractères.'], 400);
         }
+
+        // --- Interdire nom déjà utilisé ---
+        $existingClub = $em->getRepository(Club::class)->findOneBy(['name' => $name]);
+        if ($existingClub) {
+            return $this->json(['error' => "Ce nom de club existe déjà."], 400);
+        }
+
+        // --- Interdire insultes/mots interdits ---
+        $bannedWords = [
+            'pute', 'merde', 'connard', 'enculé', 'fdp', 'batard', 'ntm', 'pd', 'tg', 'salope',
+            'fuck', 'shit', 'asshole', 'bitch', 'slut', 'putain', 'chier'
+            // Ajoute ici tous les mots à bloquer...
+        ];
+        foreach ($bannedWords as $badWord) {
+            if (stripos($name, $badWord) !== false) {
+                return $this->json(['error' => "Le nom du club contient un mot interdit."], 400);
+            }
+        }
+
         $captain = $userRepository->find($data['clubCaptainId']);
         if (!$captain) {
             return $this->json(['error' => 'Club captain not found'], 404);
@@ -128,6 +147,7 @@ class ClubController extends AbstractController
             'image' => $club->getImage(),
         ]);
     }
+
 
     #[Route('/{clubId}/set-poste/{userId}', name: 'set_user_poste', methods: ['POST'])]
     public function setUserPoste(
@@ -212,6 +232,22 @@ class ClubController extends AbstractController
             if (mb_strlen($name) > 32) {
                 return $this->json(['error' => 'Le nom du club ne doit pas dépasser 32 caractères.'], 400);
             }
+            // --- Interdire nom déjà utilisé (hors celui du club actuel) ---
+            $existingClub = $em->getRepository(Club::class)->findOneBy(['name' => $name]);
+            if ($existingClub && $existingClub->getId() !== $club->getId()) {
+                return $this->json(['error' => "Ce nom de club existe déjà."], 400);
+            }
+            // --- Interdire insultes/mots interdits ---
+            $bannedWords = [
+                'pute', 'merde', 'connard', 'enculé', 'fdp', 'batard', 'ntm', 'pd', 'tg', 'salope',
+                'fuck', 'shit', 'asshole', 'bitch', 'slut', 'putain', 'chier'
+                // Ajoute ici tous les mots à bloquer...
+            ];
+            foreach ($bannedWords as $badWord) {
+                if (stripos($name, $badWord) !== false) {
+                    return $this->json(['error' => "Le nom du club contient un mot interdit."], 400);
+                }
+            }
             $club->setName($name);
         }
 
@@ -243,6 +279,7 @@ class ClubController extends AbstractController
             ]
         ]);
     }
+
 
     #[Route('/{id}/upload-logo', name: 'api_club_upload_club_logo', methods: ['POST'])]
     public function uploadLogo(Request $request, Club $club, EntityManagerInterface $em): JsonResponse

--- a/frontend/styx-app/screens/ClubDetailScreen.js
+++ b/frontend/styx-app/screens/ClubDetailScreen.js
@@ -284,7 +284,7 @@ export default function ClubDetailScreen({ route }) {
       <KeyboardAvoidingView
         style={{ flex: 1 }}
         behavior={Platform.OS === "ios" ? "padding" : undefined}
-        keyboardVerticalOffset={90}
+        keyboardVerticalOffset={0}
       >
         <ScrollView
           style={{ flex: 1 }}
@@ -907,7 +907,7 @@ const styles = StyleSheet.create({
     padding: 16,
     alignItems: 'stretch',
     marginHorizontal: 4,
-    minHeight: 490,
+    minHeight: 450,
     marginBottom: 14,
     shadowColor: '#000',
     shadowOpacity: 0.13,
@@ -917,7 +917,7 @@ const styles = StyleSheet.create({
   },
   chatMessages: {
     minHeight: 90,
-    maxHeight: 460,
+    maxHeight: 430,
     marginBottom: 12,
     borderRadius: 12,
     backgroundColor: '#202849',

--- a/frontend/styx-app/screens/ClubManageScreen.js
+++ b/frontend/styx-app/screens/ClubManageScreen.js
@@ -92,10 +92,25 @@ export default function ClubManageScreen() {
       await fetchClubData();
       Alert.alert('Succès', 'Nom du club mis à jour !');
     } catch (e) {
-      Alert.alert('Erreur', "Impossible de modifier le nom");
+      let msg = "Impossible de modifier le nom du club.";
+      if (e?.response?.data?.error) {
+        msg = e.response.data.error;
+        if (msg.includes('déjà utilisé')) {
+          msg = "Ce nom de club est déjà utilisé, choisis-en un autre.";
+        }
+        if (msg.includes('mot interdit') || msg.includes('insulte')) {
+          msg = "Le nom de club contient un mot interdit ou une insulte. Merci d'en choisir un autre.";
+        }
+        if (msg.includes('doit pas dépasser')) {
+          msg = "Le nom de club est trop long (32 caractères max).";
+        }
+      }
+      Alert.alert('Erreur', msg);
     }
     setLoading(false);
   };
+
+
 
   // Virer un membre
   const handleKick = async (memberId) => {

--- a/frontend/styx-app/screens/CreateClubScreen.js
+++ b/frontend/styx-app/screens/CreateClubScreen.js
@@ -63,7 +63,7 @@ export default function CreateClubScreen() {
     <KeyboardAvoidingView
       behavior={Platform.OS === "ios" ? "padding" : undefined}
       style={{ flex: 1 }}
-      keyboardVerticalOffset={50}
+      keyboardVerticalOffset={0}
     >
       <View style={styles.container}>
         <TouchableOpacity

--- a/frontend/styx-app/screens/CreateClubScreen.js
+++ b/frontend/styx-app/screens/CreateClubScreen.js
@@ -39,9 +39,25 @@ export default function CreateClubScreen() {
       Alert.alert('Succès', 'Club créé !');
       navigation.navigate('ClubHome');
     } catch (e) {
-      Alert.alert('Erreur', "Impossible de créer le club");
+      let msg = "Impossible de créer le club";
+      if (e?.response?.data?.error) {
+        msg = e.response.data.error;
+        // Ajout d'exemples personnalisés
+        if (msg.includes('déjà utilisé')) {
+          msg = "Ce nom de club est déjà utilisé, choisis-en un autre.";
+        }
+        if (msg.includes('mot interdit') || msg.includes('insulte')) {
+          msg = "Le nom de club contient un mot interdit ou une insulte. Merci d'en choisir un autre.";
+        }
+        if (msg.includes('doit pas dépasser')) {
+          msg = "Le nom de club est trop long (32 caractères max).";
+        }
+      }
+      Alert.alert('Erreur', msg);
     }
   };
+
+
 
   return (
     <KeyboardAvoidingView

--- a/frontend/styx-app/screens/CreateClubScreen.js
+++ b/frontend/styx-app/screens/CreateClubScreen.js
@@ -86,7 +86,9 @@ export default function CreateClubScreen() {
                   ]}
                   activeOpacity={0.8}
                 >
-                  <Image source={imgObj.img} style={styles.logoImage} resizeMode="contain" />
+                  <View style={styles.logoPreviewWrapper}>
+                    <Image source={imgObj.img} style={styles.logoImageZoomed} resizeMode="contain" />
+                  </View>
                 </TouchableOpacity>
               ))}
             </ScrollView>
@@ -107,7 +109,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'flex-start',
     paddingHorizontal: 12,
-    paddingTop: Platform.OS === 'ios' ? 80 : 36, // grand margin top pour ne pas être collé
+    paddingTop: Platform.OS === 'ios' ? 80 : 36,
   },
   backBtn: {
     alignSelf: 'flex-start',
@@ -221,9 +223,18 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.25,
     elevation: 8,
   },
-  logoImage: {
-    width: 68,
-    height: 68,
-    borderRadius: 34,
+  logoPreviewWrapper: {
+    width: 78,
+    height: 78,
+    borderRadius: 39,
+    overflow: 'hidden',
+    backgroundColor: '#222',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  logoImageZoomed: {
+    width: 140,
+    height: 140,
   },
 });
+


### PR DESCRIPTION
## 1. **Titre de la PR**

```
✨ UX: Validation des noms de clubs (mot interdit, doublons…) + affichage zoomé des logos à la création
```

---

## 2. **Description de la PR**

```
- Correction UX sur la création et la modification de club :
    - Affiche à l’utilisateur la raison précise si le nom de club est refusé (déjà utilisé, mot interdit, nom trop long, etc.), avec message en français.
    - Empêche l’envoi d’un nom interdit ou déjà utilisé.
- Ajout/alignement du style « zoom » sur les logos dans l’écran de création de club : les logos proposés sont affichés agrandis et cropés comme sur l’écran de gestion de club, pour une cohérence visuelle et un meilleur aperçu du rendu du logo du club.
```

---

## 3. **Diff principal / modifications à faire**

### **Dans CreateClubScreen.js**

1. **Remplace la logique d'affichage des logos**
   Dans la map qui affiche les choix de logos, change la vue de l’image pour :

```js
<View style={styles.logoPreviewWrapper}>
  <Image
    source={imgObj.img}
    style={styles.logoImageZoomed}
    resizeMode="contain"
  />
</View>
```

et dans le StyleSheet, ajoute :

```js
logoPreviewWrapper: {
  width: 78,
  height: 78,
  borderRadius: 39,
  overflow: 'hidden',
  backgroundColor: '#222',
  alignItems: 'center',
  justifyContent: 'center',
},
logoImageZoomed: {
  width: 140,
  height: 140,
},
```

(Comme dans le manageclubscreen.)

2. **Remplace la fonction handleCreate par** :

```js
const handleCreate = async () => {
  if (!name.trim()) {
    Alert.alert('Erreur', 'Merci de renseigner le nom du club');
    return;
  }
  try {
    await createClub({ name, clubCaptainId: userInfo?.id, image: selectedLogo });
    Alert.alert('Succès', 'Club créé !');
    navigation.navigate('ClubHome');
  } catch (e) {
    let msg = "Impossible de créer le club";
    if (e?.response?.data?.error) {
      msg = e.response.data.error;
      if (msg.includes('déjà utilisé')) {
        msg = "Ce nom de club est déjà utilisé, choisis-en un autre.";
      }
      if (msg.includes('mot interdit') || msg.includes('insulte')) {
        msg = "Le nom de club contient un mot interdit ou une insulte. Merci d'en choisir un autre.";
      }
      if (msg.includes('doit pas dépasser')) {
        msg = "Le nom de club est trop long (32 caractères max).";
      }
    }
    Alert.alert('Erreur', msg);
  }
};
```

---

### **Dans ClubManageScreen.js**

Même traitement sur la fonction `handleSaveName` pour le message d’erreur (cf. PR précédente).

---

## 4. **À tester**

* Créer un club avec un nom déjà pris ➔ message d’erreur explicite
* Créer un club avec mot interdit ➔ message d’erreur explicite
* Créer un club avec un nom trop long ➔ message d’erreur explicite
* Visualiser les logos : ils sont bien zoomés et cropés dans la liste de sélection sur l’écran de création


