### PR TITLE
Restore CSRF protection

### DIFF
--- a/backend/assets/controllers/csrf_protection_controller.js
+++ b/backend/assets/controllers/csrf_protection_controller.js
@@ -1,0 +1,79 @@
+const nameCheck = /^[-_a-zA-Z0-9]{4,22}$/;
+const tokenCheck = /^[-_\/+a-zA-Z0-9]{24,}$/;
+
+// Generate and double-submit a CSRF token in a form field and a cookie, as defined by Symfony's SameOriginCsrfTokenManager
+document.addEventListener('submit', function (event) {
+    generateCsrfToken(event.target);
+}, true);
+
+// When @hotwired/turbo handles form submissions, send the CSRF token in a header in addition to a cookie
+// The `framework.csrf_protection.check_header` config option needs to be enabled for the header to be checked
+document.addEventListener('turbo:submit-start', function (event) {
+    const h = generateCsrfHeaders(event.detail.formSubmission.formElement);
+    Object.keys(h).map(function (k) {
+        event.detail.formSubmission.fetchRequest.headers[k] = h[k];
+    });
+});
+
+// When @hotwired/turbo handles form submissions, remove the CSRF cookie once a form has been submitted
+document.addEventListener('turbo:submit-end', function (event) {
+    removeCsrfToken(event.detail.formSubmission.formElement);
+});
+
+export function generateCsrfToken (formElement) {
+    const csrfField = formElement.querySelector('input[data-controller="csrf-protection"], input[name="_csrf_token"]');
+
+    if (!csrfField) {
+        return;
+    }
+
+    let csrfCookie = csrfField.getAttribute('data-csrf-protection-cookie-value');
+    let csrfToken = csrfField.value;
+
+    if (!csrfCookie && nameCheck.test(csrfToken)) {
+        csrfField.setAttribute('data-csrf-protection-cookie-value', csrfCookie = csrfToken);
+        csrfField.defaultValue = csrfToken = btoa(String.fromCharCode.apply(null, (window.crypto || window.msCrypto).getRandomValues(new Uint8Array(18))));
+        csrfField.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+
+    if (csrfCookie && tokenCheck.test(csrfToken)) {
+        const cookie = csrfCookie + '_' + csrfToken + '=' + csrfCookie + '; path=/; samesite=strict';
+        document.cookie = window.location.protocol === 'https:' ? '__Host-' + cookie + '; secure' : cookie;
+    }
+}
+
+export function generateCsrfHeaders (formElement) {
+    const headers = {};
+    const csrfField = formElement.querySelector('input[data-controller="csrf-protection"], input[name="_csrf_token"]');
+
+    if (!csrfField) {
+        return headers;
+    }
+
+    const csrfCookie = csrfField.getAttribute('data-csrf-protection-cookie-value');
+
+    if (tokenCheck.test(csrfField.value) && nameCheck.test(csrfCookie)) {
+        headers[csrfCookie] = csrfField.value;
+    }
+
+    return headers;
+}
+
+export function removeCsrfToken (formElement) {
+    const csrfField = formElement.querySelector('input[data-controller="csrf-protection"], input[name="_csrf_token"]');
+
+    if (!csrfField) {
+        return;
+    }
+
+    const csrfCookie = csrfField.getAttribute('data-csrf-protection-cookie-value');
+
+    if (tokenCheck.test(csrfField.value) && nameCheck.test(csrfCookie)) {
+        const cookie = csrfCookie + '_' + csrfField.value + '=0; path=/; samesite=strict; max-age=0';
+
+        document.cookie = window.location.protocol === 'https:' ? '__Host-' + cookie + '; secure' : cookie;
+    }
+}
+
+/* stimulusFetch: 'lazy' */
+export default 'csrf-protection-controller';

--- a/backend/config/packages/csrf.yaml
+++ b/backend/config/packages/csrf.yaml
@@ -1,0 +1,11 @@
+# Enable stateless CSRF protection for forms and logins/logouts
+framework:
+    form:
+        csrf_protection:
+            token_id: submit
+
+    csrf_protection:
+        stateless_token_ids:
+            - submit
+            - authenticate
+            - logout

--- a/backend/src/Controller/SecurityController.php
+++ b/backend/src/Controller/SecurityController.php
@@ -1,0 +1,17 @@
+<?php
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+
+class SecurityController extends AbstractController
+{
+    #[Route('/api/csrf-token', name: 'api_csrf_token', methods: ['GET'])]
+    public function csrfToken(CsrfTokenManagerInterface $csrfTokenManager): JsonResponse
+    {
+        $token = $csrfTokenManager->getToken('api')->getValue();
+        return $this->json(['token' => $token]);
+    }
+}

--- a/backend/src/EventSubscriber/CsrfSubscriber.php
+++ b/backend/src/EventSubscriber/CsrfSubscriber.php
@@ -1,0 +1,38 @@
+<?php
+namespace App\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+use Symfony\Component\Security\Csrf\CsrfToken;
+
+class CsrfSubscriber implements EventSubscriberInterface
+{
+    public function __construct(private CsrfTokenManagerInterface $csrfTokenManager){}
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        $request = $event->getRequest();
+
+        if ($request->isMethodSafe() || !str_starts_with($request->getPathInfo(), '/api')) {
+            return;
+        }
+
+        if (in_array($request->getPathInfo(), ['/api/login', '/api/register', '/api/csrf-token'])) {
+            return;
+        }
+
+        $header = $request->headers->get('X-CSRF-TOKEN');
+        if (!$header || !$this->csrfTokenManager->isTokenValid(new CsrfToken('api', $header))) {
+            $event->setResponse(new Response('Invalid CSRF token', Response::HTTP_FORBIDDEN));
+        }
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            'kernel.request' => 'onKernelRequest',
+        ];
+    }
+}

--- a/frontend/styx-app/services/api.js
+++ b/frontend/styx-app/services/api.js
@@ -7,6 +7,25 @@ const api = axios.create({
   baseURL: API_URL,
 });
 
+let csrfToken = null;
+
+const fetchCsrfToken = async () => {
+  if (csrfToken) return csrfToken;
+  try {
+    const saved = await AsyncStorage.getItem('csrfToken');
+    if (saved) {
+      csrfToken = saved;
+    } else {
+      const response = await axios.get(`${API_URL}/csrf-token`);
+      csrfToken = response.data.token;
+      await AsyncStorage.setItem('csrfToken', csrfToken);
+    }
+  } catch (err) {
+    console.error('CSRF token fetch error', err);
+  }
+  return csrfToken;
+};
+
 // Intercepteur pour les tokens (peut être utilisé + tard si tu mets l’auth JWT côté back)
 api.interceptors.request.use(async (config) => {
   const token = await AsyncStorage.getItem('token');
@@ -17,7 +36,12 @@ api.interceptors.request.use(async (config) => {
     config.headers.Authorization = `Bearer ${token}`;
   }
 
-  // No CSRF protection needed
+  if (!['get', 'head', 'options'].includes(config.method)) {
+    const csrf = await fetchCsrfToken();
+    if (csrf) {
+      config.headers['X-CSRF-TOKEN'] = csrf;
+    }
+  }
 
   return config;
 });


### PR DESCRIPTION
## Summary
- restore CSRF management files and subscriber
- reinstate frontend CSRF token handling

## Testing
- `npm test --silent`
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a177f3ba8832fa6f060abe845452c